### PR TITLE
Corrected one time pad calculation

### DIFF
--- a/polybius.py
+++ b/polybius.py
@@ -22,7 +22,7 @@ def get_one_time_pad(numbers):
     #takes the last 2 digits for the entry and
     # creates a one time pad key used for encryption
     numbers_length = len(numbers)
-    one_time_pad = int(numbers[numbers_length -2] + numbers[numbers_length - 1])
+    one_time_pad = 10 * int(numbers[numbers_length -2]) + int(numbers[numbers_length - 1])
     return(one_time_pad)
 
 


### PR DESCRIPTION
if the last number (of two digits) is 15, we need to multiply the one by ten so we end up with 15 instead of 6.